### PR TITLE
fix typo in word "license" in badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/moteus/lua-travis-example.png?branch=master)](https://travis-ci.org/moteus/lua-travis-example)
 [![Coverage Status](https://coveralls.io/repos/moteus/lua-travis-example/badge.png?branch=master)](https://coveralls.io/r/moteus/lua-travis-example?branch=master)
-[![Licence](http://img.shields.io/badge/Licence-MIT-brightgreen.svg)](LICENSE)
+[![License](http://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
 ### This project demonstrate howto:
 * Install Lua 5.1/5.2/5.3/JIT


### PR DESCRIPTION
This repository works as an example for Lua projects using Travis CI. Prevent the spead of the typo.