### PR TITLE
Adds pip path to PATH

### DIFF
--- a/.travis/setenv_lua.sh
+++ b/.travis/setenv_lua.sh
@@ -1,3 +1,3 @@
-export PATH=${PATH}:$HOME/.lua:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
 bash .travis/setup_lua.sh
 eval `$HOME/.lua/luarocks path`


### PR DESCRIPTION
coverage data was not being generated in the _after_success_ part of the build.
Since pip is now installed locally, it's path needed to be added to PATH env var.