### PR TITLE
Build without backwards compatibility for testing

### DIFF
--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -73,6 +73,8 @@ else
     cd lua-5.3.1;
   fi
 
+  # Build Lua without backwards compatibility for testing
+  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2)//' src/Makefile
   make $PLATFORM
   make INSTALL_TOP="$LUA_HOME_DIR" install;
 


### PR DESCRIPTION
In the course of a long discussion about unpack on the Lua mailing list, Roberto
suggested this: "Run with compatibility on, but test with compatibility off." I
think that this is a good idea, so I've made this change to my CI files.